### PR TITLE
perf: added cacheTtl option to match

### DIFF
--- a/src/helpers/kv.ts
+++ b/src/helpers/kv.ts
@@ -12,9 +12,14 @@ type CachedDataDeprecated = {
   cacheTtl: string
 }
 
+export type MatchOptions = Pick<KVNamespaceGetOptions<'json'>, 'cacheTtl'>
+
 export type KVCacheStoreType = {
   put: (req: Request, res: Response) => Promise<void>
-  match: (req: Request) => Promise<[Response | null, { remainingTime: number }]>
+  match: (
+    req: Request,
+    option?: MatchOptions,
+  ) => Promise<[Response | null, { remainingTime: number }]>
   delete: (req: Request) => Promise<void>
 }
 
@@ -39,9 +44,10 @@ export const KVCacheStore = (
       )
     },
 
-    match: async (req) => {
+    match: async (req, addOptions) => {
       const res = await kv.get<CachedData | CachedDataDeprecated>(req.url, {
         type: 'json',
+        ...addOptions,
       })
       if (!res) return [null, { remainingTime: 0 }]
       const remainingTime =


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the Apache 2.0 license.
-->
## 概要
KV取得高速化のためcacheTtlオプション追加する

## 課題
KVのValueサイズに比例してget時にかかる時間が増加してしまう

| Value size | average time(milli sec) |
| ----- | ----- |
| 1.3Mib | 1,300ms |
| 216Kib | 900ms |
| 20b | 200ms |

## 対策
KV.get()の`cacheTtl`オプション指定しエッジローカル側にKV値をキャッシュすることで速度改善を行なう

（参考）https://developers.cloudflare.com/kv/api/read-key-value-pairs/#cachettl-parameter

## 改善後パフォーマンス

| Value size | average time(milli sec) |
| ----- | ----- |
| 1.3Mib | 20ms |